### PR TITLE
rename the `all-green` capstone job to `all-checks`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
           report_paths: "**/build/**/TEST-*.xml"
           check_name: Integration Test Results - windows
 
-  all-green:
+  all-checks:
     if: always()
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
This makes it consistent with all my other repos